### PR TITLE
Fix the native code to make the byte[] readonly

### DIFF
--- a/ballerina/tests/listener_tests.bal
+++ b/ballerina/tests/listener_tests.bal
@@ -153,3 +153,13 @@ function testListenerAttachDetatch() returns error? {
     check logServer.attach(dummyService);
     check logServer.detach(dummyService);
 }
+
+@test:Config {}
+function testReadOnly() returns error? {
+    ConnectClient socketClient = check new ("localhost", 9005);
+    string msg = "Echo from connect client";
+    check socketClient->writeBytes(msg.toBytes());
+    readonly & byte[] response = check socketClient->readBytes();
+    test:assertEquals(string:fromBytes(response), "true");
+    return check socketClient->close();
+}

--- a/ballerina/tests/mock_servers.bal
+++ b/ballerina/tests/mock_servers.bal
@@ -21,6 +21,7 @@ const int PORT3 = 9001;
 const int PORT4 = 9002;
 const int PORT5 = 9003;
 const int PORT6 = 9004;
+const int PORT7 = 9005;
 
 listener Listener logServer = new Listener(PORT1);
 listener Listener echoServer = new Listener(PORT2);
@@ -100,5 +101,13 @@ service on new Listener(PORT6) {
             remoteHost: <string>caller.remoteHost,
             remotePort: <int>caller.remotePort
         });
+    }
+}
+
+service on new Listener(PORT7) {
+    remote function onBytes(readonly & byte[] data) returns (readonly & byte[])|Error? {
+        string isReadOnly = (data is readonly & byte[]).toString();
+        readonly & byte[] resp = isReadOnly.toBytes().cloneReadOnly();
+        return resp;
     }
 }

--- a/examples/simple-file-server/server/udp_file_server.bal
+++ b/examples/simple-file-server/server/udp_file_server.bal
@@ -26,7 +26,7 @@ isolated service on new udp:Listener(PORT) {
 
     // Start the `sequenceNo` from zero as no data is received.
     private int sequenceNo = 0;
-    // Open a byte channel to a file to append with receving data.
+    // Open a byte channel to a file to append with receiving data.
     private io:WritableByteChannel byteChannel
         = checkpanic io:openWritableFile("dest.txt", option = io:APPEND);
 

--- a/native/src/main/java/io/ballerina/stdlib/udp/Dispatcher.java
+++ b/native/src/main/java/io/ballerina/stdlib/udp/Dispatcher.java
@@ -101,7 +101,7 @@ public class Dispatcher {
             int paramTag = param.getTag();
             switch (paramTag) {
                 case TypeTags.INTERSECTION_TAG:
-                    bValues[index++] = ValueCreator.createArrayValue(byteContent);
+                    bValues[index++] = ValueCreator.createReadonlyArrayValue(byteContent);
                     bValues[index++] = true;
                     break;
                 case TypeTags.OBJECT_TYPE_TAG:


### PR DESCRIPTION
## Purpose
Fixes: ballerina-platform/ballerina-standard-library#2636

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
