### PR TITLE
Allow returning generic `error` from remote functions

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/udp/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/udp/compiler/CompilerPluginTest.java
@@ -175,6 +175,14 @@ public class CompilerPluginTest {
     }
 
     @Test
+    public void testWithGenericErrorReturnType() {
+        Package currentPackage = loadPackage("sample_package_15");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.diagnostics().size(), 0);
+    }
+
+    @Test
     public void testWithUnSupportedFunctionNames() {
         Package currentPackage = loadPackage("sample_package_12");
         PackageCompilation compilation = currentPackage.getCompilation();

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "udp_test"
+name = "sample_15"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/bytes_service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/bytes_service.bal
@@ -1,0 +1,12 @@
+import ballerina/udp as u;
+
+service on new u:Listener(8000) {
+
+    remote function onBytes(byte[] & readonly data, u:Caller caller) returns error? {
+
+    }
+
+    remote function onError(u:Error err) returns error? {
+
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/bytes_service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/bytes_service.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/udp as u;
 
 service on new u:Listener(8000) {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/datagram_service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/datagram_service.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/udp;
 
 service on new udp:Listener(8000) {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/datagram_service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/datagram_service.bal
@@ -1,0 +1,8 @@
+import ballerina/udp;
+
+service on new udp:Listener(8000) {
+
+    remote function onDatagram(readonly & udp:Datagram datagram) returns udp:Datagram|error? {
+        return datagram;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/udp/compiler/UdpServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/udp/compiler/UdpServiceValidator.java
@@ -300,21 +300,7 @@ public class UdpServiceValidator {
         boolean isOnBytesOrOnDatagram = functionName.equals(Constants.ON_DATAGRAM)
                 || functionName.equals(Constants.ON_BYTES);
 
-        if (isOnBytesOrOnDatagram && returnTypeDescriptor.kind() == SyntaxKind.ARRAY_TYPE_DESC
-                && Utils.equals(returnTypeDescriptorType, BYTE_ARRAY)) {
-            return;
-        }
-
-        if (isOnBytesOrOnDatagram && returnTypeDescriptor.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE
-                && Utils.equals(returnTypeDescriptorType, modulePrefix + DATAGRAM)) {
-            return;
-        }
-
-        if (isOnBytesOrOnDatagram && returnTypeDescriptor.kind() == SyntaxKind.OPTIONAL_TYPE_DESC
-                && (Utils.equals(returnTypeDescriptorType, modulePrefix + ERROR + OPTIONAL)
-                || Utils.equals(returnTypeDescriptorType, modulePrefix + DATAGRAM + OPTIONAL)
-                || Utils.equals(returnTypeDescriptorType, BYTE_ARRAY + OPTIONAL)
-                || Utils.equals(returnTypeDescriptorType, GENERIC_ERROR + OPTIONAL))) {
+        if (validOnDataFunction(returnTypeDescriptor, returnTypeDescriptorType, isOnBytesOrOnDatagram)) {
             return;
         }
 
@@ -367,6 +353,28 @@ public class UdpServiceValidator {
                     returnTypeDescriptor.location(), returnTypeDescriptor.toString(), functionName,
                     modulePrefix + ERROR + " | " + NIL));
         }
+    }
+
+    private boolean validOnDataFunction(Node returnTypeDescriptor, String returnTypeDescriptorType,
+                                        boolean isOnBytesOrOnDatagram) {
+        if (isOnBytesOrOnDatagram && returnTypeDescriptor.kind() == SyntaxKind.ARRAY_TYPE_DESC
+                && Utils.equals(returnTypeDescriptorType, BYTE_ARRAY)) {
+            return true;
+        }
+
+        if (isOnBytesOrOnDatagram && returnTypeDescriptor.kind() == SyntaxKind.QUALIFIED_NAME_REFERENCE
+                && Utils.equals(returnTypeDescriptorType, modulePrefix + DATAGRAM)) {
+            return true;
+        }
+
+        if (isOnBytesOrOnDatagram && returnTypeDescriptor.kind() == SyntaxKind.OPTIONAL_TYPE_DESC
+                && (Utils.equals(returnTypeDescriptorType, modulePrefix + ERROR + OPTIONAL)
+                || Utils.equals(returnTypeDescriptorType, modulePrefix + DATAGRAM + OPTIONAL)
+                || Utils.equals(returnTypeDescriptorType, BYTE_ARRAY + OPTIONAL)
+                || Utils.equals(returnTypeDescriptorType, GENERIC_ERROR + OPTIONAL))) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/udp/compiler/UdpServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/udp/compiler/UdpServiceValidator.java
@@ -82,6 +82,7 @@ public class UdpServiceValidator {
     public static final String CALLER = "Caller";
     public static final String BYTE_ARRAY = "byte[]";
     public static final String ERROR = "Error";
+    public static final String GENERIC_ERROR = "error";
     public static final String OPTIONAL = "?";
     public static final String NIL = "()";
 
@@ -312,12 +313,14 @@ public class UdpServiceValidator {
         if (isOnBytesOrOnDatagram && returnTypeDescriptor.kind() == SyntaxKind.OPTIONAL_TYPE_DESC
                 && (Utils.equals(returnTypeDescriptorType, modulePrefix + ERROR + OPTIONAL)
                 || Utils.equals(returnTypeDescriptorType, modulePrefix + DATAGRAM + OPTIONAL)
-                || Utils.equals(returnTypeDescriptorType, BYTE_ARRAY + OPTIONAL))) {
+                || Utils.equals(returnTypeDescriptorType, BYTE_ARRAY + OPTIONAL)
+                || Utils.equals(returnTypeDescriptorType, GENERIC_ERROR + OPTIONAL))) {
             return;
         }
 
         if (functionName.equals(Constants.ON_ERROR) && returnTypeDescriptor.kind() == SyntaxKind.OPTIONAL_TYPE_DESC
-                && Utils.equals(returnTypeDescriptorType, modulePrefix + ERROR + OPTIONAL)) {
+                && (Utils.equals(returnTypeDescriptorType, modulePrefix + ERROR + OPTIONAL)
+                || Utils.equals(returnTypeDescriptorType, GENERIC_ERROR + OPTIONAL))) {
             return;
         }
 
@@ -343,6 +346,7 @@ public class UdpServiceValidator {
                 } else if (descriptor.kind() == SyntaxKind.OPTIONAL_TYPE_DESC
                         && (Utils.equals(descriptorType, modulePrefix + ERROR + OPTIONAL)
                         || Utils.equals(descriptorType, modulePrefix + DATAGRAM + OPTIONAL)
+                        || Utils.equals(descriptorType, GENERIC_ERROR + OPTIONAL)
                         || Utils.equals(descriptorType, BYTE_ARRAY + OPTIONAL))) {
                     continue;
                 } else {


### PR DESCRIPTION
## Purpose
$subject.
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/2691

## Examples

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the specification~
- [ ] ~Updated the changelog~
- [x] Added tests
